### PR TITLE
move repo name to the end of the message title

### DIFF
--- a/src/issue-handlers.ts
+++ b/src/issue-handlers.ts
@@ -35,9 +35,9 @@ export const openIssue: OnCallback<Webhooks.WebhookPayloadIssues> = async (conte
   const avatarUrl = context.payload.repository.owner.avatar_url
 
   const title = [
-    fullName,
     `#${issueNumber}`,
     issueTitle.slice(0, Math.max(issueTitle.length, 30)),
+    fullName,
   ].join(' ')
   const url = htmlUrl
   const description = issueBody.slice(0, Math.max(issueBody.length, 70))


### PR DESCRIPTION
## I'm submitting a...

```
[ ] Bug Fix
[ x ] Feature
[ ] Other (Refactoring, Added tests, Documentation, ...)
```

## Description

As described in #83 , I am trying to move the Repo name to the end of the message title.
It is because in many cases, the Wechat group that the message will be sent to only receives message from the same repo. In this case, the repo name is repeated in all messages.


