### PR TITLE
fix: remove incubator words for the DolphinScheduler

### DIFF
--- a/src/projects/apache.ts
+++ b/src/projects/apache.ts
@@ -9,7 +9,7 @@ import {
 }                 from './config'
 
 export const config: RepoConfig = {
-  'apache/incubator-dolphinscheduler'     : [
+  'apache/dolphinscheduler'     : [
     '8676247154@chatroom',
     '19237597168@chatroom',
     '19380384367@chatroom',


### PR DESCRIPTION

## I'm submitting a...

```
 Bug Fix

```

## Checklist

- [ ] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

DolphinScheduler github repo have removed the 'incubator-' words, maybe this is the cause why we can't receive the msg from osschat



## Does this PR introduce a breaking change?

```
No
```
